### PR TITLE
Fixed paths to configs

### DIFF
--- a/src/io/github/yannici/bedwars/Game/GameManager.java
+++ b/src/io/github/yannici/bedwars/Game/GameManager.java
@@ -86,8 +86,8 @@ public class GameManager {
 			return;
 		}
 		
-		File configs = new File(Main.getInstance().getDataFolder() + "/"
-				+ GameManager.gamesPath + "/" + game.getName());
+		File configs = new File(Main.getInstance().getDataFolder() + File.separator
+				+ GameManager.gamesPath + File.separator + game.getName());
 		
 		if(configs.exists()) {
 			configs.delete();
@@ -110,7 +110,7 @@ public class GameManager {
 	}
 
 	public void loadGames() {
-		String path = Main.getInstance().getDataFolder() + "/"
+		String path = Main.getInstance().getDataFolder() + File.separator
 				+ GameManager.gamesPath;
 		File file = new File(path);
 
@@ -214,9 +214,9 @@ public class GameManager {
 			Location loc1 = Utils.locationDeserialize(cfg.get("loc1"));
 			Location loc2 = Utils.locationDeserialize(cfg.get("loc2"));
 
-			File signFile = new File(Main.getInstance().getDataFolder() + "/"
-					+ GameManager.gamesPath + "/" + game.getName()
-					+ "/sign.yml");
+			File signFile = new File(Main.getInstance().getDataFolder() + File.separator
+					+ GameManager.gamesPath + File.separator + game.getName()
+					, "sign.yml");
 			if (signFile.exists()) {
 				YamlConfiguration signConfig = YamlConfiguration
 						.loadConfiguration(signFile);


### PR DESCRIPTION
You can't use "/" because 
Windows use: \
Linux use: /
This way you must declare separator "File.separator" 

And File constructor = (path, filename)
it's mean new File(dataFolderPath, "config.yml"); not new File(dataFolderPath + "/config.yml")

This maybe fix plugin on Java 8. Where it can't find games.
Good luck