### PR TITLE
Player leaves the game if he changes the world.

### DIFF
--- a/src/io/github/yannici/bedwars/Commands/JoinGameCommand.java
+++ b/src/io/github/yannici/bedwars/Commands/JoinGameCommand.java
@@ -4,7 +4,6 @@ import io.github.yannici.bedwars.ChatWriter;
 import io.github.yannici.bedwars.Main;
 import io.github.yannici.bedwars.Game.Game;
 import io.github.yannici.bedwars.Game.GameState;
-import io.github.yannici.bedwars.Listener.PlayerListener;
 
 import java.util.ArrayList;
 
@@ -42,26 +41,13 @@ public class JoinGameCommand extends BaseCommand {
 
 	@Override
 	public boolean execute(CommandSender sender, ArrayList<String> args) {
+		if (!super.hasPermission(sender)) {
+			return false;
+		}
+
 		Player player = (Player) sender;
 		Game game = this.getPlugin().getGameManager().getGame(args.get(0));
 		Game gameOfPlayer = Main.getInstance().getGameManager().getGameOfPlayer(player);
-		
-		//If a player joins the Bedwars game, he should never leave it directly.
-		//Only if the lobby is not in the same world!
-		if(game != null) {
-			if(!game.getLobby().getWorld().getName().equalsIgnoreCase(player.getWorld().getName())){
-				if (PlayerListener.playersLeavingOrJoining.containsKey(player.getUniqueId().toString())) {
-    				PlayerListener.playersLeavingOrJoining.remove(player.getUniqueId().toString());
-    				PlayerListener.playersLeavingOrJoining.put(player.getUniqueId().toString(), true);
-    			} else {
-    				PlayerListener.playersLeavingOrJoining.put(player.getUniqueId().toString(), true);
-    			}
-		
-				if (!super.hasPermission(sender)) {
-					return false;
-				}
-			}
-		}
 		
 		if(gameOfPlayer != null) {
 			if(gameOfPlayer.getState() == GameState.RUNNING) {

--- a/src/io/github/yannici/bedwars/Commands/JoinGameCommand.java
+++ b/src/io/github/yannici/bedwars/Commands/JoinGameCommand.java
@@ -4,6 +4,7 @@ import io.github.yannici.bedwars.ChatWriter;
 import io.github.yannici.bedwars.Main;
 import io.github.yannici.bedwars.Game.Game;
 import io.github.yannici.bedwars.Game.GameState;
+import io.github.yannici.bedwars.Listener.PlayerListener;
 
 import java.util.ArrayList;
 
@@ -41,13 +42,26 @@ public class JoinGameCommand extends BaseCommand {
 
 	@Override
 	public boolean execute(CommandSender sender, ArrayList<String> args) {
-		if (!super.hasPermission(sender)) {
-			return false;
-		}
-
 		Player player = (Player) sender;
 		Game game = this.getPlugin().getGameManager().getGame(args.get(0));
 		Game gameOfPlayer = Main.getInstance().getGameManager().getGameOfPlayer(player);
+		
+		//If a player joins the Bedwars game, he should never leave it directly.
+		//Only if the lobby is not in the same world!
+		if(game != null) {
+			if(!game.getLobby().getWorld().getName().equalsIgnoreCase(player.getWorld().getName())){
+				if (PlayerListener.playersLeavingOrJoining.containsKey(player.getUniqueId().toString())) {
+    				PlayerListener.playersLeavingOrJoining.remove(player.getUniqueId().toString());
+    				PlayerListener.playersLeavingOrJoining.put(player.getUniqueId().toString(), true);
+    			} else {
+    				PlayerListener.playersLeavingOrJoining.put(player.getUniqueId().toString(), true);
+    			}
+		
+				if (!super.hasPermission(sender)) {
+					return false;
+				}
+			}
+		}
 		
 		if(gameOfPlayer != null) {
 			if(gameOfPlayer.getState() == GameState.RUNNING) {

--- a/src/io/github/yannici/bedwars/Game/Game.java
+++ b/src/io/github/yannici/bedwars/Game/Game.java
@@ -8,7 +8,6 @@ import io.github.yannici.bedwars.Events.BedwarsPlayerJoinEvent;
 import io.github.yannici.bedwars.Events.BedwarsPlayerJoinedEvent;
 import io.github.yannici.bedwars.Events.BedwarsPlayerLeaveEvent;
 import io.github.yannici.bedwars.Events.BedwarsSaveGameEvent;
-import io.github.yannici.bedwars.Listener.PlayerListener;
 import io.github.yannici.bedwars.Shop.NewItemShop;
 import io.github.yannici.bedwars.Shop.Specials.SpecialItem;
 import io.github.yannici.bedwars.Statistics.PlayerStatistic;
@@ -585,14 +584,6 @@ public class Game {
 	}
 
     public boolean playerLeave(Player p, boolean kicked) {
-    	//Stores true to the HashMap because the player is leaving
-    	if (PlayerListener.playersLeavingOrJoining.containsKey(p.getUniqueId().toString())) {
-    		PlayerListener.playersLeavingOrJoining.remove(p.getUniqueId().toString());
-    		PlayerListener.playersLeavingOrJoining.put(p.getUniqueId().toString(), true);
-    	} else {
-    		PlayerListener.playersLeavingOrJoining.put(p.getUniqueId().toString(), true);
-    	}
-    	
 		BedwarsPlayerLeaveEvent leaveEvent = new BedwarsPlayerLeaveEvent(this,
 				p);
 		Main.getInstance().getServer().getPluginManager().callEvent(leaveEvent);
@@ -701,13 +692,6 @@ public class Game {
 		
 		this.updateSigns();
 		this.storages.remove(p);
-		
-		//If the HashMap contains the player, the destination was in the same world
-		//--> remove this element because it is no longer needed
-    	if (PlayerListener.playersLeavingOrJoining.containsKey(p.getUniqueId().toString())) {
-    		PlayerListener.playersLeavingOrJoining.remove(p.getUniqueId().toString());
-    	}
-		
 		return true;
 	}
 
@@ -1752,18 +1736,6 @@ public class Game {
 			for (Player player : team.getPlayers()) {
 				player.setVelocity(new Vector(0, 0, 0));
 				player.setFallDistance(0.0F);
-				
-				//If the Team spawn location is not in the same world as the player's current world
-				//He should not leave Bedwars, because he is being teleported on purpose.
-				if(!player.getWorld().getName().equalsIgnoreCase(team.getSpawnLocation().getWorld().getName())){
-					if (PlayerListener.playersLeavingOrJoining.containsKey(player.getUniqueId().toString())) {
-		    			PlayerListener.playersLeavingOrJoining.remove(player.getUniqueId().toString());
-		    			PlayerListener.playersLeavingOrJoining.put(player.getUniqueId().toString(), true);
-		    		} else {
-		    			PlayerListener.playersLeavingOrJoining.put(player.getUniqueId().toString(), true);
-		    		}
-				}
-				
 				player.teleport(team.getSpawnLocation());
 				if(this.getPlayerStorage(player) != null) {
 				    this.getPlayerStorage(player).clean();

--- a/src/io/github/yannici/bedwars/Game/Game.java
+++ b/src/io/github/yannici/bedwars/Game/Game.java
@@ -537,6 +537,11 @@ public class Game {
 		
 		if (this.state == GameState.RUNNING) {
 	        this.toSpectator(p);
+	        
+			if(!this.lobby.getWorld().getName().equalsIgnoreCase(p.getWorld().getName())) {
+				this.getPlayerSettings(p).setTeleporting(true);
+			}
+	        
             p.teleport(((Team) this.teams.values().toArray()[Utils.randInt(0,
                     this.teams.size() - 1)]).getSpawnLocation());
             this.displayMapInfo(p);
@@ -554,6 +559,9 @@ public class Game {
 			storage.store();
 			storage.clean();
 
+			if(!this.lobby.getWorld().getName().equalsIgnoreCase(p.getWorld().getName())) {
+				this.getPlayerSettings(p).setTeleporting(true);
+			}
 			p.teleport(this.lobby);
 			storage.loadLobbyInventory(this);
 			
@@ -584,6 +592,7 @@ public class Game {
 	}
 
     public boolean playerLeave(Player p, boolean kicked) {
+    	this.getPlayerSettings(p).setTeleporting(true);
 		BedwarsPlayerLeaveEvent leaveEvent = new BedwarsPlayerLeaveEvent(this,
 				p);
 		Main.getInstance().getServer().getPluginManager().callEvent(leaveEvent);
@@ -1734,6 +1743,9 @@ public class Game {
 	private void teleportPlayersToTeamSpawn() {
 		for (Team team : this.teams.values()) {
 			for (Player player : team.getPlayers()) {
+				if (!player.getWorld().getName().equalsIgnoreCase(team.getSpawnLocation().getWorld().getName())) {
+					this.getPlayerSettings(player).setTeleporting(true);
+				}
 				player.setVelocity(new Vector(0, 0, 0));
 				player.setFallDistance(0.0F);
 				player.teleport(team.getSpawnLocation());

--- a/src/io/github/yannici/bedwars/Game/Game.java
+++ b/src/io/github/yannici/bedwars/Game/Game.java
@@ -8,6 +8,7 @@ import io.github.yannici.bedwars.Events.BedwarsPlayerJoinEvent;
 import io.github.yannici.bedwars.Events.BedwarsPlayerJoinedEvent;
 import io.github.yannici.bedwars.Events.BedwarsPlayerLeaveEvent;
 import io.github.yannici.bedwars.Events.BedwarsSaveGameEvent;
+import io.github.yannici.bedwars.Listener.PlayerListener;
 import io.github.yannici.bedwars.Shop.NewItemShop;
 import io.github.yannici.bedwars.Shop.Specials.SpecialItem;
 import io.github.yannici.bedwars.Statistics.PlayerStatistic;
@@ -584,6 +585,14 @@ public class Game {
 	}
 
     public boolean playerLeave(Player p, boolean kicked) {
+    	//Stores true to the HashMap because the player is leaving
+    	if (PlayerListener.playersLeaving.containsKey(p.getUniqueId().toString())) {
+    		PlayerListener.playersLeaving.remove(p.getUniqueId().toString());
+    		PlayerListener.playersLeaving.put(p.getUniqueId().toString(), true);
+    	} else {
+    		PlayerListener.playersLeaving.put(p.getUniqueId().toString(), true);
+    	}
+    	
 		BedwarsPlayerLeaveEvent leaveEvent = new BedwarsPlayerLeaveEvent(this,
 				p);
 		Main.getInstance().getServer().getPluginManager().callEvent(leaveEvent);

--- a/src/io/github/yannici/bedwars/Game/Game.java
+++ b/src/io/github/yannici/bedwars/Game/Game.java
@@ -586,11 +586,11 @@ public class Game {
 
     public boolean playerLeave(Player p, boolean kicked) {
     	//Stores true to the HashMap because the player is leaving
-    	if (PlayerListener.playersLeaving.containsKey(p.getUniqueId().toString())) {
-    		PlayerListener.playersLeaving.remove(p.getUniqueId().toString());
-    		PlayerListener.playersLeaving.put(p.getUniqueId().toString(), true);
+    	if (PlayerListener.playersLeavingOrJoining.containsKey(p.getUniqueId().toString())) {
+    		PlayerListener.playersLeavingOrJoining.remove(p.getUniqueId().toString());
+    		PlayerListener.playersLeavingOrJoining.put(p.getUniqueId().toString(), true);
     	} else {
-    		PlayerListener.playersLeaving.put(p.getUniqueId().toString(), true);
+    		PlayerListener.playersLeavingOrJoining.put(p.getUniqueId().toString(), true);
     	}
     	
 		BedwarsPlayerLeaveEvent leaveEvent = new BedwarsPlayerLeaveEvent(this,
@@ -701,6 +701,13 @@ public class Game {
 		
 		this.updateSigns();
 		this.storages.remove(p);
+		
+		//If the HashMap contains the player, the destination was in the same world
+		//--> remove this element because it is no longer needed
+    	if (PlayerListener.playersLeavingOrJoining.containsKey(p.getUniqueId().toString())) {
+    		PlayerListener.playersLeavingOrJoining.remove(p.getUniqueId().toString());
+    	}
+		
 		return true;
 	}
 
@@ -1745,6 +1752,18 @@ public class Game {
 			for (Player player : team.getPlayers()) {
 				player.setVelocity(new Vector(0, 0, 0));
 				player.setFallDistance(0.0F);
+				
+				//If the Team spawn location is not in the same world as the player's current world
+				//He should not leave Bedwars, because he is being teleported on purpose.
+				if(!player.getWorld().getName().equalsIgnoreCase(team.getSpawnLocation().getWorld().getName())){
+					if (PlayerListener.playersLeavingOrJoining.containsKey(player.getUniqueId().toString())) {
+		    			PlayerListener.playersLeavingOrJoining.remove(player.getUniqueId().toString());
+		    			PlayerListener.playersLeavingOrJoining.put(player.getUniqueId().toString(), true);
+		    		} else {
+		    			PlayerListener.playersLeavingOrJoining.put(player.getUniqueId().toString(), true);
+		    		}
+				}
+				
 				player.teleport(team.getSpawnLocation());
 				if(this.getPlayerStorage(player) != null) {
 				    this.getPlayerStorage(player).clean();

--- a/src/io/github/yannici/bedwars/Game/PlayerSettings.java
+++ b/src/io/github/yannici/bedwars/Game/PlayerSettings.java
@@ -9,6 +9,7 @@ public class PlayerSettings {
     private Player player = null;
     private boolean oneStackPerShift = false;
     private Object hologram = null;
+    private boolean isTeleporting = false;
 
     public PlayerSettings(Player player) {
         this.player = player;
@@ -34,5 +35,13 @@ public class PlayerSettings {
     public void setOneStackPerShift(boolean value) {
         this.oneStackPerShift = value;
     }
+
+	public boolean isTeleporting() {
+		return isTeleporting;
+	}
+
+	public void setTeleporting(boolean isTeleporting) {
+		this.isTeleporting = isTeleporting;
+	}
 
 }

--- a/src/io/github/yannici/bedwars/Listener/PlayerListener.java
+++ b/src/io/github/yannici/bedwars/Listener/PlayerListener.java
@@ -3,7 +3,6 @@ package io.github.yannici.bedwars.Listener;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 
@@ -63,9 +62,6 @@ import org.bukkit.scheduler.BukkitRunnable;
 import com.gmail.filoghost.holographicdisplays.api.Hologram;
 
 public class PlayerListener extends BaseListener {
-	
-	//HashMap, which stores whether the player (UUID of player) is leaving or not
-	public static HashMap<String, Boolean> playersLeavingOrJoining = new HashMap<String, Boolean>();
 
 	public PlayerListener() {
 		super();
@@ -125,18 +121,15 @@ public class PlayerListener extends BaseListener {
 	
 	@EventHandler
 	public void onSwitchWorld(PlayerChangedWorldEvent change) {
-		
-		//If the Player changes the world and he is not changing the world because he leaves the game and he is playing a Bedwars game,
-		//he will leave the Bedwars game.
-		if (!PlayerListener.playersLeavingOrJoining.containsKey(change.getPlayer().getUniqueId().toString()) &&
-				Main.getInstance().getGameManager().getGameOfPlayer(change.getPlayer()) != null) {
-			Main.getInstance().getGameManager().getGameOfPlayer(change.getPlayer()).playerLeave(change.getPlayer(), false);
-		} else if (PlayerListener.playersLeavingOrJoining.containsKey(change.getPlayer().getUniqueId().toString())) {
-			if (PlayerListener.playersLeavingOrJoining.get(change.getPlayer().getUniqueId().toString()) == true) {
-				PlayerListener.playersLeavingOrJoining.remove(change.getPlayer().getUniqueId().toString());
+		Game game = Main.getInstance().getGameManager().getGameOfPlayer(change.getPlayer());
+		if(game != null) {
+			if(game.getState() == GameState.RUNNING) {
+				if(!game.getCycle().isEndGameRunning()) {
+					game.playerLeave(change.getPlayer(), false);
+				}
 			}
 		}
-		
+
 	    if(!Main.getInstance().isHologramsEnabled() 
                 || Main.getInstance().getHolographicInteractor() == null) {
 	        return;

--- a/src/io/github/yannici/bedwars/Listener/PlayerListener.java
+++ b/src/io/github/yannici/bedwars/Listener/PlayerListener.java
@@ -65,7 +65,7 @@ import com.gmail.filoghost.holographicdisplays.api.Hologram;
 public class PlayerListener extends BaseListener {
 	
 	//HashMap, which stores whether the player (UUID of player) is leaving or not
-	public static HashMap<String, Boolean> playersLeaving = new HashMap<String, Boolean>();
+	public static HashMap<String, Boolean> playersLeavingOrJoining = new HashMap<String, Boolean>();
 
 	public PlayerListener() {
 		super();
@@ -128,12 +128,12 @@ public class PlayerListener extends BaseListener {
 		
 		//If the Player changes the world and he is not changing the world because he leaves the game and he is playing a Bedwars game,
 		//he will leave the Bedwars game.
-		if (!PlayerListener.playersLeaving.containsKey(change.getPlayer().getUniqueId().toString()) ||
+		if (!PlayerListener.playersLeavingOrJoining.containsKey(change.getPlayer().getUniqueId().toString()) &&
 				Main.getInstance().getGameManager().getGameOfPlayer(change.getPlayer()) != null) {
 			Main.getInstance().getGameManager().getGameOfPlayer(change.getPlayer()).playerLeave(change.getPlayer(), false);
-		} else if (PlayerListener.playersLeaving.containsKey(change.getPlayer().getUniqueId().toString())) {
-			if (PlayerListener.playersLeaving.get(change.getPlayer().getUniqueId().toString()) == true) {
-				PlayerListener.playersLeaving.remove(change.getPlayer().getUniqueId().toString());
+		} else if (PlayerListener.playersLeavingOrJoining.containsKey(change.getPlayer().getUniqueId().toString())) {
+			if (PlayerListener.playersLeavingOrJoining.get(change.getPlayer().getUniqueId().toString()) == true) {
+				PlayerListener.playersLeavingOrJoining.remove(change.getPlayer().getUniqueId().toString());
 			}
 		}
 		

--- a/src/io/github/yannici/bedwars/Listener/PlayerListener.java
+++ b/src/io/github/yannici/bedwars/Listener/PlayerListener.java
@@ -125,7 +125,17 @@ public class PlayerListener extends BaseListener {
 		if(game != null) {
 			if(game.getState() == GameState.RUNNING) {
 				if(!game.getCycle().isEndGameRunning()) {
+					if(!game.getPlayerSettings(change.getPlayer()).isTeleporting()) {
+						game.playerLeave(change.getPlayer(), false);
+					} else {
+						game.getPlayerSettings(change.getPlayer()).setTeleporting(false);
+					}
+				}
+			} else if(game.getState() == GameState.WAITING) {
+				if(!game.getPlayerSettings(change.getPlayer()).isTeleporting()) {
 					game.playerLeave(change.getPlayer(), false);
+				} else {
+					game.getPlayerSettings(change.getPlayer()).setTeleporting(false);
 				}
 			}
 		}

--- a/src/io/github/yannici/bedwars/Listener/PlayerListener.java
+++ b/src/io/github/yannici/bedwars/Listener/PlayerListener.java
@@ -3,6 +3,7 @@ package io.github.yannici.bedwars.Listener;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 
@@ -62,6 +63,9 @@ import org.bukkit.scheduler.BukkitRunnable;
 import com.gmail.filoghost.holographicdisplays.api.Hologram;
 
 public class PlayerListener extends BaseListener {
+	
+	//HashMap, which stores whether the player (UUID of player) is leaving or not
+	public static HashMap<String, Boolean> playersLeaving = new HashMap<String, Boolean>();
 
 	public PlayerListener() {
 		super();
@@ -121,6 +125,18 @@ public class PlayerListener extends BaseListener {
 	
 	@EventHandler
 	public void onSwitchWorld(PlayerChangedWorldEvent change) {
+		
+		//If the Player changes the world and he is not changing the world because he leaves the game and he is playing a Bedwars game,
+		//he will leave the Bedwars game.
+		if (!PlayerListener.playersLeaving.containsKey(change.getPlayer().getUniqueId().toString()) ||
+				Main.getInstance().getGameManager().getGameOfPlayer(change.getPlayer()) != null) {
+			Main.getInstance().getGameManager().getGameOfPlayer(change.getPlayer()).playerLeave(change.getPlayer(), false);
+		} else if (PlayerListener.playersLeaving.containsKey(change.getPlayer().getUniqueId().toString())) {
+			if (PlayerListener.playersLeaving.get(change.getPlayer().getUniqueId().toString()) == true) {
+				PlayerListener.playersLeaving.remove(change.getPlayer().getUniqueId().toString());
+			}
+		}
+		
 	    if(!Main.getInstance().isHologramsEnabled() 
                 || Main.getInstance().getHolographicInteractor() == null) {
 	        return;


### PR DESCRIPTION
This function is needed if a player types in a command like /lobby and
is currently playing Bedwars. He will be automatically removed from that
game.

For our server, we want to have a basic command (/lobby) for all minigames. Currently we wrote a simple plugin which listens to the PlayerChangedWorldEvent and triggers the command /bw leave.
The problem is, this method is not always working because it sometimes triggers too early or too late.
I think this option could be also useful for others, so I am sharing my solution.

Basically if you change your world with a command other than /bw leave, you'll automatically leave the game you are currently in.