### PR TITLE
Fix quit bug (experimental)

### DIFF
--- a/src/io/github/yannici/bedwars/Listener/PlayerListener.java
+++ b/src/io/github/yannici/bedwars/Listener/PlayerListener.java
@@ -422,8 +422,8 @@ public class PlayerListener extends BaseListener {
 	        	}
 	        	
 	            Material clickedMat = ice.getCurrentItem().getType();
-	            if(clickedMat.equals(Material.SLIME_BALL)) {
-	                game.playerLeave(player, false);
+	            if(clickedMat.equals(Material.SLIME_BALL) && game.getCycle() instanceof BungeeGameCycle) {
+	                ((BungeeGameCycle) game.getCycle()).bungeeSendToServer(Main.getInstance().getBungeeHub(), player, true);
 	            }
 	            
 	            if(clickedMat.equals(Material.COMPASS)) {


### PR DESCRIPTION
Sending player to hub spawn can sometimes result in a bug where player is denied access (if it's full, for example) and hence isn't registered on the bedwars server anymore.