### PR TITLE
[1.2.8] Fix team selection movable items

### DIFF
--- a/src/io/github/yannici/bedwars/Listener/PlayerListener.java
+++ b/src/io/github/yannici/bedwars/Listener/PlayerListener.java
@@ -943,6 +943,7 @@ public class PlayerListener extends BaseListener {
 		}
 
 		if (clickedStack.getType() != Material.WOOL) {
+			ice.setCancelled(true);
 			return;
 		}
 


### PR DESCRIPTION
Material is not Material.WOOL, then set InventoryClickEvent cancelled
Fixes #339 