### PR TITLE
[1.2.8] Add endgame in lobby feature for Bungeecord

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -561,6 +561,11 @@ bungeecord:
   # the server where the player will be teleported when they leave.
     hubserver: hub
     
+  # Endgame Lobby
+  # type: boolean
+  # If true, it sends players to your lobby during the endgame before getting kicked.
+    endgame-in-lobby: true
+    
   # Full server restart
   # Type: boolean
   # If true, the server will do a full restart, with false

--- a/src/io/github/yannici/bedwars/Game/BungeeGameCycle.java
+++ b/src/io/github/yannici/bedwars/Game/BungeeGameCycle.java
@@ -228,6 +228,8 @@ public class BungeeGameCycle extends GameCycle {
 
 				if (!player.getWorld().equals(this.getGame().getLobby().getWorld())) {
 					player.getInventory().clear();
+					this.getGame().getPlayerSettings(player).setTeleporting(true);
+					player.teleport(this.getGame().getLobby());
 
 					// lobby gamemode
 					GameMode mode = GameMode.SURVIVAL;
@@ -241,8 +243,10 @@ public class BungeeGameCycle extends GameCycle {
 						mode = GameMode.SURVIVAL;
 					}
 					player.setGameMode(mode);
-					this.getGame().getPlayerSettings(player).setTeleporting(true);
-					player.teleport(this.getGame().getLobby());
+					
+					for (Player playerToShow : players) {
+						player.showPlayer(playerToShow);
+					}
 				}
 			}
 		}

--- a/src/io/github/yannici/bedwars/Game/BungeeGameCycle.java
+++ b/src/io/github/yannici/bedwars/Game/BungeeGameCycle.java
@@ -227,10 +227,11 @@ public class BungeeGameCycle extends GameCycle {
 			for (Player player : players) {
 
 				if (!player.getWorld().equals(this.getGame().getLobby().getWorld())) {
-					player.getInventory().clear();
 					this.getGame().getPlayerSettings(player).setTeleporting(true);
 					player.teleport(this.getGame().getLobby());
 
+					this.getGame().getPlayerStorage(player).clean();
+					
 					// lobby gamemode
 					GameMode mode = GameMode.SURVIVAL;
 					try {
@@ -243,7 +244,7 @@ public class BungeeGameCycle extends GameCycle {
 						mode = GameMode.SURVIVAL;
 					}
 					player.setGameMode(mode);
-					
+
 					for (Player playerToShow : players) {
 						player.showPlayer(playerToShow);
 					}

--- a/src/io/github/yannici/bedwars/Game/BungeeGameCycle.java
+++ b/src/io/github/yannici/bedwars/Game/BungeeGameCycle.java
@@ -12,6 +12,7 @@ import io.github.yannici.bedwars.Events.BedwarsGameEndEvent;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -216,6 +217,7 @@ public class BungeeGameCycle extends GameCycle {
 		}.runTaskLater(Main.getInstance(), (preventDelay) ? 0L : 20L);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public void onGameOver(GameOverTask task) {
 		if (Main.getInstance().getBooleanConfig("bungeecord.endgame-in-lobby", true)) {
@@ -223,7 +225,22 @@ public class BungeeGameCycle extends GameCycle {
 			players.addAll(this.getGame().getTeamPlayers());
 			players.addAll(this.getGame().getFreePlayers());
 			for (Player player : players) {
+
 				if (!player.getWorld().equals(this.getGame().getLobby().getWorld())) {
+					player.getInventory().clear();
+
+					// lobby gamemode
+					GameMode mode = GameMode.SURVIVAL;
+					try {
+						mode = GameMode.getByValue(Main.getInstance().getIntConfig("lobby-gamemode", 0));
+					} catch (Exception ex) {
+						// not valid gamemode
+					}
+
+					if (mode == null) {
+						mode = GameMode.SURVIVAL;
+					}
+					player.setGameMode(mode);
 					this.getGame().getPlayerSettings(player).setTeleporting(true);
 					player.teleport(this.getGame().getLobby());
 				}

--- a/src/io/github/yannici/bedwars/Game/BungeeGameCycle.java
+++ b/src/io/github/yannici/bedwars/Game/BungeeGameCycle.java
@@ -2,6 +2,7 @@ package io.github.yannici.bedwars.Game;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
+import java.util.ArrayList;
 import java.util.List;
 
 import io.github.yannici.bedwars.ChatWriter;
@@ -28,70 +29,70 @@ public class BungeeGameCycle extends GameCycle {
 	public void onGameStart() {
 		// do nothing, world will be reseted on restarting
 	}
-	
+
 	private void kickAllPlayers() {
-	    for (Player player : this.getGame().getTeamPlayers()) {
-            for (Player freePlayer : this.getGame().getFreePlayers()) {
-                player.showPlayer(freePlayer);
-            }
-            this.getGame().playerLeave(player, false);
-        }
-        
-        for (Player freePlayer : this.getGame().getFreePlayersClone()) {
-            this.getGame().playerLeave(freePlayer, false);
-        }
+		for (Player player : this.getGame().getTeamPlayers()) {
+			for (Player freePlayer : this.getGame().getFreePlayers()) {
+				player.showPlayer(freePlayer);
+			}
+			this.getGame().playerLeave(player, false);
+		}
+
+		for (Player freePlayer : this.getGame().getFreePlayersClone()) {
+			this.getGame().playerLeave(freePlayer, false);
+		}
 	}
 
 	@Override
 	public void onGameEnds() {
-	    if(Main.getInstance().getBooleanConfig("bungeecord.full-restart", true)) {
-	        this.kickAllPlayers();
-	        
-    		this.getGame().resetRegion();
-    		new BukkitRunnable() {
-                
-                @Override
-                public void run() {
-                	if(Main.getInstance().isSpigot() 
-                			&& Main.getInstance().getBooleanConfig("bungeecord.spigot-restart", true)) {
-                		Main.getInstance().getServer().dispatchCommand(Main.getInstance().getServer().getConsoleSender(), "restart");
-                	} else {
-                		Bukkit.shutdown();
-                	}
-                }
-            }.runTaskLater(Main.getInstance(), 70L);
-	    } else {
-	        // Reset scoreboard first
-	        this.getGame().resetScoreboard();
+		if (Main.getInstance().getBooleanConfig("bungeecord.full-restart", true)) {
+			this.kickAllPlayers();
 
-	        // Kick all players
-	        this.kickAllPlayers();
+			this.getGame().resetRegion();
+			new BukkitRunnable() {
 
-	        // reset countdown prevention breaks
-	        this.setEndGameRunning(false);
+				@Override
+				public void run() {
+					if (Main.getInstance().isSpigot()
+							&& Main.getInstance().getBooleanConfig("bungeecord.spigot-restart", true)) {
+						Main.getInstance().getServer()
+								.dispatchCommand(Main.getInstance().getServer().getConsoleSender(), "restart");
+					} else {
+						Bukkit.shutdown();
+					}
+				}
+			}.runTaskLater(Main.getInstance(), 70L);
+		} else {
+			// Reset scoreboard first
+			this.getGame().resetScoreboard();
 
-	        // Reset team chests
-	        for (Team team : this.getGame().getTeams().values()) {
-	            team.setInventory(null);
-	            team.getChests().clear();
-	        }
-	        
-	        // clear protections
-	        this.getGame().clearProtections();
-	        
-	        // set state and with that, the sign
-	        this.getGame().setState(GameState.WAITING);
-	        this.getGame().updateScoreboard();
-	        
-	        // reset region
-	        this.getGame().resetRegion();
-	    }
+			// Kick all players
+			this.kickAllPlayers();
+
+			// reset countdown prevention breaks
+			this.setEndGameRunning(false);
+
+			// Reset team chests
+			for (Team team : this.getGame().getTeams().values()) {
+				team.setInventory(null);
+				team.getChests().clear();
+			}
+
+			// clear protections
+			this.getGame().clearProtections();
+
+			// set state and with that, the sign
+			this.getGame().setState(GameState.WAITING);
+			this.getGame().updateScoreboard();
+
+			// reset region
+			this.getGame().resetRegion();
+		}
 	}
 
 	@Override
 	public void onPlayerLeave(Player player) {
-		if (player.isOnline()
-				|| player.isDead()) {
+		if (player.isOnline() || player.isDead()) {
 			this.bungeeSendToServer(Main.getInstance().getBungeeHub(), player, true);
 		}
 
@@ -108,76 +109,65 @@ public class BungeeGameCycle extends GameCycle {
 	@Override
 	public boolean onPlayerJoins(Player player) {
 		final Player p = player;
-		
+
 		if (this.getGame().isFull() && !player.hasPermission("bw.vip.joinfull")) {
-			if (this.getGame().getState() != GameState.RUNNING
-					|| !Main.getInstance().spectationEnabled()) {
+			if (this.getGame().getState() != GameState.RUNNING || !Main.getInstance().spectationEnabled()) {
 				this.bungeeSendToServer(Main.getInstance().getBungeeHub(), p, false);
 				new BukkitRunnable() {
 
 					@Override
 					public void run() {
-						BungeeGameCycle.this.sendBungeeMessage(
-								p,
-								ChatWriter.pluginMessage(ChatColor.RED
-										+ Main._l("lobby.gamefull")));
+						BungeeGameCycle.this.sendBungeeMessage(p,
+								ChatWriter.pluginMessage(ChatColor.RED + Main._l("lobby.gamefull")));
 					}
 				}.runTaskLater(Main.getInstance(), 60L);
 
 				return false;
 			}
-		} else if(this.getGame().isFull() && player.hasPermission("bw.vip.joinfull")) {
-			if(this.getGame().getState() == GameState.WAITING) {
+		} else if (this.getGame().isFull() && player.hasPermission("bw.vip.joinfull")) {
+			if (this.getGame().getState() == GameState.WAITING) {
 				List<Player> players = this.getGame().getNonVipPlayers();
-				
-				if(players.size() == 0) {
-					this.bungeeSendToServer(Main.getInstance().getBungeeHub(),
-							p, false);
+
+				if (players.size() == 0) {
+					this.bungeeSendToServer(Main.getInstance().getBungeeHub(), p, false);
 					new BukkitRunnable() {
 
 						@Override
 						public void run() {
-							BungeeGameCycle.this.sendBungeeMessage(
-									p,
-									ChatWriter.pluginMessage(ChatColor.RED
-											+ Main._l("lobby.gamefullpremium")));
+							BungeeGameCycle.this.sendBungeeMessage(p,
+									ChatWriter.pluginMessage(ChatColor.RED + Main._l("lobby.gamefullpremium")));
 						}
 					}.runTaskLater(Main.getInstance(), 60L);
 					return false;
 				}
-				
+
 				Player kickPlayer = null;
-				if(players.size() == 1) {
+				if (players.size() == 1) {
 					kickPlayer = players.get(0);
 				} else {
-					kickPlayer = players.get(Utils.randInt(0, players.size()-1));
+					kickPlayer = players.get(Utils.randInt(0, players.size() - 1));
 				}
-				
+
 				final Player kickedPlayer = kickPlayer;
-				
+
 				this.getGame().playerLeave(kickedPlayer, false);
 				new BukkitRunnable() {
 
 					@Override
 					public void run() {
-						BungeeGameCycle.this.sendBungeeMessage(
-								kickedPlayer,
+						BungeeGameCycle.this.sendBungeeMessage(kickedPlayer,
 								ChatWriter.pluginMessage(ChatColor.RED + Main._l("lobby.kickedbyvip")));
 					}
 				}.runTaskLater(Main.getInstance(), 60L);
 			} else {
-				if(this.getGame().getState() == GameState.RUNNING
-						&& !Main.getInstance().spectationEnabled()) {
-					this.bungeeSendToServer(Main.getInstance().getBungeeHub(),
-							p, false);
+				if (this.getGame().getState() == GameState.RUNNING && !Main.getInstance().spectationEnabled()) {
+					this.bungeeSendToServer(Main.getInstance().getBungeeHub(), p, false);
 					new BukkitRunnable() {
 
 						@Override
 						public void run() {
-							BungeeGameCycle.this.sendBungeeMessage(
-									p,
-									ChatWriter.pluginMessage(ChatColor.RED
-											+ Main._l("lobby.gamefull")));
+							BungeeGameCycle.this.sendBungeeMessage(p,
+									ChatWriter.pluginMessage(ChatColor.RED + Main._l("lobby.gamefull")));
 						}
 					}.runTaskLater(Main.getInstance(), 60L);
 					return false;
@@ -189,80 +179,73 @@ public class BungeeGameCycle extends GameCycle {
 	}
 
 	public void sendBungeeMessage(Player player, String message) {
-	    ByteArrayDataOutput out = ByteStreams.newDataOutput();
-	    
-	    out.writeUTF("Message");
-	    out.writeUTF(player.getName());
-	    out.writeUTF(message);
-	    
-	    player.sendPluginMessage(Main.getInstance(), "BungeeCord", out.toByteArray());
+		ByteArrayDataOutput out = ByteStreams.newDataOutput();
+
+		out.writeUTF("Message");
+		out.writeUTF(player.getName());
+		out.writeUTF(message);
+
+		player.sendPluginMessage(Main.getInstance(), "BungeeCord", out.toByteArray());
 	}
 
 	public void bungeeSendToServer(final String server, final Player player, boolean preventDelay) {
 		if (server == null) {
-			player.sendMessage(ChatWriter.pluginMessage(ChatColor.RED
-					+ Main._l("errors.bungeenoserver")));
+			player.sendMessage(ChatWriter.pluginMessage(ChatColor.RED + Main._l("errors.bungeenoserver")));
 			return;
 		}
 
 		new BukkitRunnable() {
-            
-            @Override
-            public void run() {
-                ByteArrayOutputStream b = new ByteArrayOutputStream();
-                DataOutputStream out = new DataOutputStream(b);
 
-                try {
-                    out.writeUTF("Connect");
-                    out.writeUTF(server);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                    return;
-                }
+			@Override
+			public void run() {
+				ByteArrayOutputStream b = new ByteArrayOutputStream();
+				DataOutputStream out = new DataOutputStream(b);
 
-                if (b != null) {
-                    player.sendPluginMessage(Main.getInstance(), "BungeeCord",
-                            b.toByteArray());
-                }
-            }
-        }.runTaskLater(Main.getInstance(), (preventDelay) ? 0L : 20L);
+				try {
+					out.writeUTF("Connect");
+					out.writeUTF(server);
+				} catch (Exception e) {
+					e.printStackTrace();
+					return;
+				}
+
+				if (b != null) {
+					player.sendPluginMessage(Main.getInstance(), "BungeeCord", b.toByteArray());
+				}
+			}
+		}.runTaskLater(Main.getInstance(), (preventDelay) ? 0L : 20L);
 	}
 
 	@Override
 	public void onGameOver(GameOverTask task) {
-		if (task.getCounter() == task.getStartCount()
-				&& task.getWinner() != null) {
-			this.getGame()
-					.broadcast(
-							ChatColor.GOLD
-									+ Main._l("ingame.teamwon", ImmutableMap
-											.of("team", task.getWinner()
-													.getDisplayName()
-													+ ChatColor.GOLD)));
-		} else if (task.getCounter() == task.getStartCount()
-				&& task.getWinner() == null) {
+		if (Main.getInstance().getBooleanConfig("bungeecord.endgame-in-lobby", true)) {
+			ArrayList<Player> players = new ArrayList<Player>();
+			players.addAll(this.getGame().getTeamPlayers());
+			players.addAll(this.getGame().getFreePlayers());
+			for (Player player : players) {
+				if (!player.getWorld().equals(this.getGame().getLobby().getWorld())) {
+					this.getGame().getPlayerSettings(player).setTeleporting(true);
+					player.teleport(this.getGame().getLobby());
+				}
+			}
+		}
+		if (task.getCounter() == task.getStartCount() && task.getWinner() != null) {
+			this.getGame().broadcast(ChatColor.GOLD + Main._l("ingame.teamwon",
+					ImmutableMap.of("team", task.getWinner().getDisplayName() + ChatColor.GOLD)));
+		} else if (task.getCounter() == task.getStartCount() && task.getWinner() == null) {
 			this.getGame().broadcast(ChatColor.GOLD + Main._l("ingame.draw"));
 		}
 
 		// game over
 		if (task.getCounter() == 0) {
-			BedwarsGameEndEvent endEvent = new BedwarsGameEndEvent(
-					this.getGame());
-			Main.getInstance().getServer().getPluginManager()
-					.callEvent(endEvent);
+			BedwarsGameEndEvent endEvent = new BedwarsGameEndEvent(this.getGame());
+			Main.getInstance().getServer().getPluginManager().callEvent(endEvent);
 
 			this.onGameEnds();
 			task.cancel();
 		} else {
-			this.getGame().broadcast(
-					ChatColor.AQUA
-							+ Main._l(
-									"ingame.serverrestart",
-									ImmutableMap.of(
-											"sec",
-											ChatColor.YELLOW.toString()
-													+ task.getCounter()
-													+ ChatColor.AQUA)));
+			this.getGame().broadcast(ChatColor.AQUA + Main._l("ingame.serverrestart",
+					ImmutableMap.of("sec", ChatColor.YELLOW.toString() + task.getCounter() + ChatColor.AQUA)));
 		}
 
 		task.decCounter();

--- a/src/io/github/yannici/bedwars/Updater/ConfigUpdater.java
+++ b/src/io/github/yannici/bedwars/Updater/ConfigUpdater.java
@@ -176,6 +176,8 @@ public class ConfigUpdater {
 		// <1.2.8>
 		Main.getInstance().getConfig().addDefault("specials.tntsheep.explosion-factor", 1.0);
 		Main.getInstance().getConfig().addDefault("bungeecord.full-restart", true);
+		Main.getInstance().getConfig().addDefault("lobbytime-full", 15);
+		Main.getInstance().getConfig().addDefault("bungeecord.endgame-in-lobby", true);
 		// </1.2.8>
 	}
 	


### PR DESCRIPTION
If ``bungeecord.endgame-in-lobby`` is set to ``true``, players are getting teleported to the lobby for the endgame. In the lobby, player inventory and game mode and visibility for other players (spectators!) is being reset.