### PR TITLE
Map reset on game end at non-bungee games #305

### DIFF
--- a/src/main/java/io/github/yannici/bedwars/Game/SingleGameCycle.java
+++ b/src/main/java/io/github/yannici/bedwars/Game/SingleGameCycle.java
@@ -22,7 +22,7 @@ public class SingleGameCycle extends GameCycle {
 
 	@Override
 	public void onGameStart() {
-		this.getGame().resetRegion();
+		// Reset on game end
 	}
 
 	@Override
@@ -52,6 +52,9 @@ public class SingleGameCycle extends GameCycle {
 
 		// clear protections
 		this.getGame().clearProtections();
+
+		// reset region
+		this.getGame().resetRegion();
 
 		// Restart lobby directly?
 		GameLobbyCountdownRule rule = Main.getInstance().getLobbyCountdownRule();
@@ -142,7 +145,7 @@ public class SingleGameCycle extends GameCycle {
 
 	@Override
 	public void onGameLoaded() {
-		// reset on start
+		// Reset on game end
 	}
 
 	@Override


### PR DESCRIPTION
This sould fix @nuttah Problem at #305

@Yannici Because if a game only resets on game-start you could never shutdown your server without a broken map.
@nuttah can you test it? I don't test it yet.