### PR TITLE
Catch error onDisable Plugin

### DIFF
--- a/src/main/java/io/github/yannici/bedwars/Game/Game.java
+++ b/src/main/java/io/github/yannici/bedwars/Game/Game.java
@@ -270,7 +270,12 @@ public class Game {
 
 		this.stopWorkers();
 		this.clearProtections();
-		this.kickAllPlayers();
+		
+		try {
+			this.kickAllPlayers();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
 		this.resetRegion();
 		this.state = GameState.STOPPED;
 		this.updateSigns();

--- a/src/main/java/io/github/yannici/bedwars/Game/GameManager.java
+++ b/src/main/java/io/github/yannici/bedwars/Game/GameManager.java
@@ -103,7 +103,12 @@ public class GameManager {
 
 		game.setState(GameState.STOPPED);
 		game.setScoreboard(Main.getInstance().getScoreboardManager().getNewScoreboard());
-		game.kickAllPlayers();
+		
+		try {
+			game.kickAllPlayers();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
 		game.resetRegion();
 		game.updateSigns();
 	}


### PR DESCRIPTION
This is **not** a fix, but it fix that the Region don't get reset on stop Server.

On spigotmc.org:
> @Yannici, can you fix so the plugin automatically ends the game onDisable (when the server shuts down)? 

I know that this is not the best solution because it don't fix the problem on shutdown. But i think a lot of issues like "mapreset don't work" comes from this and the last commited place.

So if you want to fix this error feel free to close this issue. But if not, this will help until the error is fixed.
I don't hide the error extra, so it don't fall into oblivion.


The problem is that we can't use:

```JavaScript
new BukkitRunnable() {

		}.runTaskLater()
```
or
```javascript
player.sendPluginMessage(Main.getInstance(), "BungeeCord", b.toByteArray());
```
while onDisable.